### PR TITLE
Example widget showing "Similar" sites based on subsite category.

### DIFF
--- a/includes/class-multisite-directory-widget.php
+++ b/includes/class-multisite-directory-widget.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * The Multisite Directory Widget
+ *
+ * @license https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * @copyright Copyright (c) 2016 TK-TODO
+ *
+ * @package WordPress\Plugin\Multisite_Directory
+ */
+
+/**
+ * The widget implementation.
+ *
+ * @link https://developer.wordpress.org/reference/classes/WP_Widget/
+ */
+class Multisite_Directory_Widget extends WP_Widget {
+
+    public function __construct () {
+        parent::__construct(
+            strtolower(__CLASS__),
+            __('Network Directory Widget', 'multisite-directory'),
+            array(
+                'description' => __('Shows a portion of the Sites from the Network Directory.', 'multisite-directory')
+            )
+        );
+    }
+
+    /**
+     * Outputs the widget's settings form HTML.
+     *
+     * @param array $instance
+     *
+     * @return string
+     */
+    public function form ($instance) {
+    }
+
+    /**
+     * Updates the widget instance.
+     *
+     * @link https://developer.wordpress.org/reference/classes/wp_widget/update/
+     *
+     * @param array $new_instance
+     * @param array $old_instance
+     *
+     * @return array|bool Settings to save or bool false to cancel saving.
+     */
+    public function update ($new_instance, $old_instance) {
+    }
+
+    /**
+     * Outputs widget HTML.
+     *
+     * @link https://developer.wordpress.org/reference/classes/wp_widget/widget/
+     *
+     * @param array $args
+     * @param array $instance
+     *
+     * @return void
+     */
+    public function widget ($args, $instance) {
+        $terms = get_site_terms(get_current_blog_id());
+        if (!is_wp_error($terms) && !empty($terms)) {
+?>
+<h1><?php esc_html_e('Similar sites', 'multisite-directory');?></h1>
+<ul class="network-directory-similar-sites">
+    <?php foreach ($terms as $term) { $similar_sites = get_sites_in_directory_by_term($term); ?>
+    <li><?php print esc_html($term->name); ?>
+        <ul>
+        <?php foreach ($similar_sites as $site_detail) { if (get_current_blog_id() == $site_detail->blog_id) { continue; } ?>
+        <li>
+            <a href="<?php print esc_url($site_detail->siteurl);?>"><?php print esc_html($site_detail->blogname);?></a>
+        </li>
+        <?php } ?>
+        </ul>
+    </li>
+    <?php } ?>
+</ul>
+<?php
+        }
+    }
+
+}

--- a/includes/class-multisite-directory-widget.php
+++ b/includes/class-multisite-directory-widget.php
@@ -37,7 +37,8 @@ class Multisite_Directory_Widget extends WP_Widget {
         $instance = wp_parse_args($instance, array(
             // Widget defaults.
             'only_locations' => 0,
-            'show_site_logo'  => 1,
+            'show_site_logo' => 1,
+            'site_logo_size' => 'post-thumbnail',
         ));
 ?>
 <p>
@@ -61,6 +62,20 @@ class Multisite_Directory_Widget extends WP_Widget {
     <label for="<?php print $this->get_field_id('show_site_logo');?>">
         <?php esc_html_e('Show site logos', 'multisite-directory');?>
     </label>
+    <label for="<?php print $this->get_field_id('site_logo_size');?>">
+        <?php
+        /* translators: Part of the logo size widget, like "Show site logo at size: " */
+        esc_html_e('at size', 'multisite-directory');
+        ?>
+    </label>
+    <select
+        id="<?php print $this->get_field_id('site_logo_size');?>"
+        name="<?php print $this->get_field_name('site_logo_size');?>"
+    >
+        <?php foreach (get_intermediate_image_sizes() as $size) { if (has_image_size($size)) : ?>
+        <option <?php selected($instance['site_logo_size'], $size);?>><?php print esc_html($size);?></option>
+        <?php endif; } ?>
+    </select>
 </p>
 <?php
     }
@@ -80,6 +95,7 @@ class Multisite_Directory_Widget extends WP_Widget {
 
         $instance['only_locations'] = (int) $new_instance['only_locations'];
         $instance['show_site_logo'] = (int) $new_instance['show_site_logo'];
+        $instance['site_logo_size'] = (has_image_size($new_instance['site_logo_size'])) ? $new_instance['site_logo_size'] : 0;
 
         return $instance;
     }
@@ -118,7 +134,7 @@ class Multisite_Directory_Widget extends WP_Widget {
         <ul>
         <?php foreach ($similar_sites as $site_detail) { if (get_current_blog_id() == $site_detail->blog_id) { continue; } ?>
         <li>
-            <?php if (!empty($instance['show_site_logo'])) { the_site_directory_logo($site_detail->blog_id); } ?>
+            <?php if (!empty($instance['show_site_logo'])) { the_site_directory_logo($site_detail->blog_id, $instance['site_logo_size']); } ?>
             <a href="<?php print esc_url($site_detail->siteurl);?>"><?php print esc_html($site_detail->blogname);?></a>
         </li>
         <?php } ?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -57,6 +57,38 @@ if (!function_exists('get_site_terms')) :
     }
 endif;
 
+if (!function_exists('get_sites_in_directory_by_term')) :
+    /**
+     * Retrieves the details of sites in the directory assigned the given term.
+     *
+     * @param WP_Term $term
+     * @param array $args
+     *
+     * @return array
+     */
+    function get_sites_in_directory_by_term ($term, $args = array()) {
+        $args = wp_parse_args($args, array(
+            'numberposts' => -1,
+            'tax_query' => array(
+                array(
+                    'taxonomy' => $term->taxonomy,
+                    'field' => 'id',
+                    'terms' => array($term->term_id),
+                ),
+            ),
+        ));
+        $cpt = new Multisite_Directory_Entry();
+        $posts = $cpt->get_posts($args);
+        $details = array();
+        switch_to_blog(1);
+        foreach ($posts as $post) {
+            $details[] = get_blog_details($post->{$cpt::blog_id_meta_key});
+        }
+        restore_current_blog();
+        return $details;
+    }
+endif;
+
 if (!function_exists('the_site_directory_logo')) :
     /**
      * Prints the site's custom logo or the site directory entry's featured image, if it has one.

--- a/multisite-directory.php
+++ b/multisite-directory.php
@@ -35,10 +35,12 @@ class WP_Multisite_Directory {
     public static function register () {
         require_once 'includes/class-multisite-directory-taxonomy.php';
         require_once 'includes/class-multisite-directory-entry.php';
+        require_once 'includes/class-multisite-directory-widget.php';
         require_once 'includes/functions.php';
         require_once 'admin/class-multisite-directory-admin.php';
 
         add_action('init', array(__CLASS__, 'initialize'));
+        add_action('widgets_init', array(__CLASS__, 'widgets_initialize'));
         add_action('wpmu_new_blog', array(__CLASS__, 'wpmu_new_blog'));
         add_action('network_admin_menu', array('WP_Multisite_Directory_Admin', 'network_admin_menu'));
         add_action('signup_blogform', array(__CLASS__, 'signup_blogform'));
@@ -60,6 +62,17 @@ class WP_Multisite_Directory {
 
         $cpt = new Multisite_Directory_Entry();
         $cpt->register();
+    }
+
+    /**
+     * Registers plugin widgets.
+     *
+     * @link https://developer.wordpress.org/reference/hooks/widgets_init/
+     *
+     * @uses register_widget()
+     */
+    public static function widgets_initialize () {
+        register_widget('Multisite_Directory_Widget');
     }
 
     /**


### PR DESCRIPTION
@misfist With regards to the discussion of Site Admin controls in #3, here's a simple example widget provided by the plugin that will work across the network for each site. All it does now is provide a list of other sites in the directory that are categorized the same as the current site, but it should serve as a decent example of how to go about fleshing things out.

I agree with you that this is the sort of the thing the plugin itself should provide for individual (sub)Site Admins, though I could use some guidance determining which _exact_ "sorts of things" like this the plugin should do and which are better off left to the Theme authors.

Could probably use input from @aurovrata as well since I know he has needs of a similar "Site Directory" functionality.
