### PR TITLE
Shortcode improvements

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -115,7 +115,7 @@ if (!function_exists('get_sites_in_directory_by_term')) :
      *
      * @param WP_Term $term
      * @param array $args
-     * @param string $exclude Optional. IDs of categories to exclude. Sites with these categories will be excluded from the list.
+     * @param array $exclude Optional. IDs of categories to exclude. Sites with these categories will be excluded from the list.
      *
      * @return array
      */


### PR DESCRIPTION
This is something else I've been working on this week :) and implements basic funcionality for selecting and excluding categories from the directory listing via shortcode, using the `terms` and `exclude` attributes. Both attributes are space-separated lists of category slugs. 

The `terms` implementation is pretty straightforward and uses the `slug` parameter of `get_terms()`. For the exclusion, I also added rules to the `tax_query` parameter of `get_posts()`, so sites with multiple categories get excluded from the list too.
